### PR TITLE
jansson 2.14.0 - fix win build

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,8 +2,12 @@ mkdir "%SRC_DIR%"\build
 pushd "%SRC_DIR%"\build
 
 cmake -G "Ninja" ^
-      -DBUILD_SHARED_LIBS=ON ^
       -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DJANSSON_BUILD_SHARED_LIBS=ON ^
+      -DJANSSON_BUILD_DOCS=OFF ^
+      -DJANSSON_EXAMPLES=OFF ^
+      %CMAKE_ARGS% ^
       ..
 if errorlevel 1 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,8 +33,9 @@ test:
     - IF NOT EXIST %LIBRARY_BIN%\\jansson.dll exit 1     # [win]
     # check if the import library exists
     - IF NOT EXIST %LIBRARY_LIB%\\jansson.lib exit 1     # [win]
+    - lib.exe  # [win]
     # check if the produced lib file is an import library (ok) or a static library (not ok)
-    - LIB /LIST %LIBRARY_LIB%\jansson.lib | find ".obj" >nul && (echo "Error static .lib found" & exit /b 1) || exit /b 0  # [win]
+    - lib.exe /LIST %LIBRARY_LIB%\jansson.lib | find ".obj" >nul && (echo "Error static .lib found" & exit /b 1) || exit /b 0  # [win]
     
 about:
   home: https://github.com/akheron/jansson

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,10 @@ requirements:
 
 test:
   commands:
-    - test ! -f ${PREFIX}/lib/libjansson.a          # [unix]
-    - test -f ${PREFIX}/lib/libjansson${SHLIB_EXT}  # [unix]
-
+    - test ! -f ${PREFIX}/lib/libjansson.a            # [unix]
+    - test -f ${PREFIX}/lib/libjansson${SHLIB_EXT}    # [unix]
+    - IF NOT EXIST %LIBRARY_BIN%\\jansson.dll exit 1  # [win]
+    
 about:
   home: https://github.com/akheron/jansson
   license: MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,9 +30,9 @@ test:
     - test ! -f ${PREFIX}/lib/libjansson.a               # [unix]
     - test -f ${PREFIX}/lib/libjansson${SHLIB_EXT}       # [unix]
     # check if the dynamic library exists
-    - IF NOT EXIST %LIBRARY_BIN%\\jansson.dll exit 1     # [win]
+    - IF NOT EXIST %LIBRARY_BIN%\jansson.dll exit 1     # [win]
     # check if the import library exists
-    - IF NOT EXIST %LIBRARY_LIB%\\jansson.lib exit 1     # [win]
+    - IF NOT EXIST %LIBRARY_LIB%\jansson.lib exit 1     # [win]
     # check if the produced lib file is an import library (ok) or a static library (not ok)
     # - lib.exe /LIST %LIBRARY_LIB%\jansson.lib > out.txt  # [win]
     # - find ".obj" out.txt >nul && (echo "Error static .lib found" & exit /b 1) || exit /b 0  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,13 +34,12 @@ test:
     - IF NOT EXIST %LIBRARY_BIN%\\jansson.dll exit 1     # [win]
     # check if the import library exists
     - IF NOT EXIST %LIBRARY_LIB%\\jansson.lib exit 1     # [win]
-    - echo %VSINSTALLDIR%
-    - echo %VCToolsInstallDir%
-    - dir %VCToolsInstallDir%
-    # - lib.exe  # [win]
+
     # check if the produced lib file is an import library (ok) or a static library (not ok)
-    - lib.exe /LIST %LIBRARY_LIB%\jansson.lib | find ".obj" >nul && (echo "Error static .lib found" & exit /b 1) || exit /b 0  # [win]
-    
+    - lib.exe /LIST %LIBRARY_LIB%\jansson.lib  # [win]
+    - lib.exe /LIST %LIBRARY_LIB%\jansson.lib > out.txt  # [win]
+    - find ".obj" out.txt >nul && (echo "Error static .lib found" & exit /b 1) || exit /b 0  # [win]
+
 about:
   home: https://github.com/akheron/jansson
   license: MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 1
+  skip: true  # [not win]
   run_exports:
     - {{ pin_subpackage('jansson', max_pin='x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 1
-  skip: true  # [not win]
   run_exports:
     - {{ pin_subpackage('jansson', max_pin='x') }}
 
@@ -34,11 +33,9 @@ test:
     - IF NOT EXIST %LIBRARY_BIN%\\jansson.dll exit 1     # [win]
     # check if the import library exists
     - IF NOT EXIST %LIBRARY_LIB%\\jansson.lib exit 1     # [win]
-
     # check if the produced lib file is an import library (ok) or a static library (not ok)
-    - lib.exe /LIST %LIBRARY_LIB%\jansson.lib  # [win]
-    - lib.exe /LIST %LIBRARY_LIB%\jansson.lib > out.txt  # [win]
-    - find ".obj" out.txt >nul && (echo "Error static .lib found" & exit /b 1) || exit /b 0  # [win]
+    # - lib.exe /LIST %LIBRARY_LIB%\jansson.lib > out.txt  # [win]
+    # - find ".obj" out.txt >nul && (echo "Error static .lib found" & exit /b 1) || exit /b 0  # [win]
 
 about:
   home: https://github.com/akheron/jansson

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,10 @@ test:
     - IF NOT EXIST %LIBRARY_BIN%\\jansson.dll exit 1     # [win]
     # check if the import library exists
     - IF NOT EXIST %LIBRARY_LIB%\\jansson.lib exit 1     # [win]
-    - lib.exe  # [win]
+    - echo %VSINSTALLDIR%
+    - echo %VCToolsInstallDir%
+    - dir %VCToolsInstallDir%
+    # - lib.exe  # [win]
     # check if the produced lib file is an import library (ok) or a static library (not ok)
     - lib.exe /LIST %LIBRARY_LIB%\jansson.lib | find ".obj" >nul && (echo "Error static .lib found" & exit /b 1) || exit /b 0  # [win]
     

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "jansson" %}
 {% set version = "2.14" %}
 
 package:
-  name: jansson
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/akheron/jansson/archive/v{{ version }}.tar.gz
+  url: https://github.com/akheron/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: c739578bf6b764aa0752db9a2fdadcfe921c78f1228c7ec0bb47fa804c55d17b
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: c739578bf6b764aa0752db9a2fdadcfe921c78f1228c7ec0bb47fa804c55d17b
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('jansson', max_pin='x') }}
 
@@ -26,17 +26,30 @@ requirements:
 
 test:
   commands:
-    - test ! -f ${PREFIX}/lib/libjansson.a            # [unix]
-    - test -f ${PREFIX}/lib/libjansson${SHLIB_EXT}    # [unix]
-    - IF NOT EXIST %LIBRARY_BIN%\\jansson.dll exit 1  # [win]
+    - test ! -f ${PREFIX}/lib/libjansson.a               # [unix]
+    - test -f ${PREFIX}/lib/libjansson${SHLIB_EXT}       # [unix]
+    # check if the dynamic library exists
+    - IF NOT EXIST %LIBRARY_BIN%\\jansson.dll exit 1     # [win]
+    # check if the import library exists
+    - IF NOT EXIST %LIBRARY_LIB%\\jansson.lib exit 1     # [win]
+    # check if the produced lib file is an import library (ok) or a static library (not ok)
+    - LIB /LIST %LIBRARY_LIB%\jansson.lib | find ".obj" >nul && (echo "Error static .lib found" & exit /b 1) || exit /b 0  # [win]
     
 about:
   home: https://github.com/akheron/jansson
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'Jansson is a C library for encoding, decoding and manipulating JSON data.'
-  doc_url: https://jansson.readthedocs.io/en/latest/
+  summary: Jansson is a C library for encoding, decoding and manipulating JSON data.
+  description: |
+    Jansson is a C library for encoding, decoding and manipulating JSON data.
+    Its main features and design principles are:
+      Simple and intuitive API and data model
+      Comprehensive documentation
+      No dependencies on other libraries
+      Full Unicode support (UTF-8)
+      Extensive test suite
+  doc_url: https://jansson.readthedocs.io
   dev_url: https://github.com/akheron/jansson
 
 extra:


### PR DESCRIPTION
jansson 2.14.0

**Destination channel:** defaults

### Links

- [PKG-3871]
- https://github.com/akheron/jansson/tree/v2.14

### Dependency for

- AnacondaRecipes/yara-python-feedstock#1

### Explanation of changes:

- fix win build


[PKG-3871]: https://anaconda.atlassian.net/browse/PKG-3871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ