### PR TITLE
jansson 2.15.0 

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,6 +7,7 @@ cmake -G "Ninja" ^
       -DJANSSON_BUILD_SHARED_LIBS=ON ^
       -DJANSSON_BUILD_DOCS=OFF ^
       -DJANSSON_EXAMPLES=OFF ^
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
       %CMAKE_ARGS% ^
       ..
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,4 +15,7 @@ EOF
 chmod +x test/suites/api/check-exports
 
 make install
-make check || { cat "${SRC_DIR}/test/test-suite.log"; exit 1; }
+
+# Copy janssonConfig.cmake into the package
+mkdir -p ${PREFIX}/lib/cmake/jansson
+cp "${RECIPE_DIR}/janssonConfig.cmake" "${PREFIX}/lib/cmake/jansson/janssonConfig.cmake"

--- a/recipe/janssonConfig.cmake
+++ b/recipe/janssonConfig.cmake
@@ -1,0 +1,22 @@
+# janssonConfig.cmake
+include_guard(GLOBAL)
+
+if(NOT TARGET jansson::jansson)
+  find_package(PkgConfig REQUIRED QUIET)
+  pkg_check_modules(JANSSON REQUIRED jansson)
+
+  add_library(jansson::jansson INTERFACE IMPORTED)
+  set_target_properties(jansson::jansson PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${JANSSON_INCLUDE_DIRS}"
+    INTERFACE_LINK_LIBRARIES "${JANSSON_LIBRARIES}"
+  )
+
+  message(STATUS "janssonConfig.cmake shim by conda-forge: created imported target jansson::jansson "
+                 "from pkg-config (${JANSSON_VERSION})")
+else()
+  message(STATUS "janssonConfig.cmake shim: using existing jansson::jansson target")
+endif()
+
+set(JANSSON_LIBRARIES "${JANSSON_LIBRARIES}")
+set(JANSSON_INCLUDE_DIRS "${JANSSON_INCLUDE_DIRS}")
+set(JANSSON_VERSION "${JANSSON_VERSION}")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,29 +1,29 @@
 {% set name = "jansson" %}
-{% set version = "2.14" %}
+{% set version = "2.15.0" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/akheron/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: c739578bf6b764aa0752db9a2fdadcfe921c78f1228c7ec0bb47fa804c55d17b
+  url: https://github.com/akheron/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 73ac12bbc62ff536e40c7a3e15ed007993c5ca4d23897de23f1906f891b5a4bb
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('jansson', max_pin='x') }}
 
 requirements:
   build:
+    - {{ stdlib('c') }}
+    - {{ compiler('c') }}
     - automake  # [not win]
     - autoconf  # [not win]
-    - libtool   # [not win]
-    - make      # [not win]
-    - cmake     # [win]
-    - ninja     # [win]
-    - {{ compiler('c') }}
-  host:
+    - libtool  # [not win]
+    - make  # [not win]
+    - cmake  # [win]
+    - ninja-base  # [win]
 
 test:
   commands:


### PR DESCRIPTION
jansson 2.15.0 

**Destination channel:** Defaults

### Links

- [PKG-13927]
- dev_url:        https://github.com/akheron/jansson/tree/v2.15.0
- conda_forge:    https://github.com/conda-forge/jansson-feedstock
- pypi:           https://www.google.com/
- pypi inspector: https://www.google.com/

### Explanation of changes:

- new version number


[PKG-13927]: https://anaconda.atlassian.net/browse/PKG-13927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ